### PR TITLE
Update so that python 3.10 doesn't complain.

### DIFF
--- a/pynamd/cphlog.py
+++ b/pynamd/cphlog.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import json
 import warnings
 
@@ -67,7 +67,7 @@ def _validate_float(value):
     return float(value)
 
 
-class TitratableSystemSet(collections.Mapping):
+class TitratableSystemSet(collections.abc.Mapping):
     """A dict-like object containing multiple TitratableSystems sorted by pH.
     """
     # These should always be compared with str(method).lower()
@@ -893,7 +893,7 @@ class TitratableSystemSet(collections.Mapping):
             raise ValueError('Unrecognized MSMLE method %s'%str(est_method))
 
 
-class TitratableSystem(collections.Mapping):
+class TitratableSystem(collections.abc.Mapping):
     """A system of multiple titratable residues in contact with the same pH
 
     Parameters

--- a/pynamd/cphlog.py
+++ b/pynamd/cphlog.py
@@ -1,4 +1,7 @@
-import collections.abc
+try:
+	from collections import Mapping
+except ImportError:
+	from collections.abc import Mapping
 import json
 import warnings
 
@@ -67,7 +70,7 @@ def _validate_float(value):
     return float(value)
 
 
-class TitratableSystemSet(collections.abc.Mapping):
+class TitratableSystemSet(Mapping):
     """A dict-like object containing multiple TitratableSystems sorted by pH.
     """
     # These should always be compared with str(method).lower()
@@ -893,7 +896,7 @@ class TitratableSystemSet(collections.abc.Mapping):
             raise ValueError('Unrecognized MSMLE method %s'%str(est_method))
 
 
-class TitratableSystem(collections.abc.Mapping):
+class TitratableSystem(Mapping):
     """A system of multiple titratable residues in contact with the same pH
 
     Parameters


### PR DESCRIPTION
In python3.10, you can't import from collections anymore, as apparently all the cool kids now use collections.abc (since python3.3). See: https://docs.python.org/3/library/collections.abc.html