### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from distutils.core import setup
-from distutils.command.build_py import build_py
+from setuptools import setup
+from setuptools.command.build_py import build_py
 
 if __name__ == '__main__':
     setup(name = 'pynamd',


### PR DESCRIPTION
Distutils is dead in python 3.12 https://docs.python.org/3/whatsnew/3.12.html. Instead, folks are supposed to use setuptools.... Well, folks technically aren't supposed to use that either, but this will work for now.